### PR TITLE
Generators never directly access the tree

### DIFF
--- a/codegeneration/csharp/Generator.js
+++ b/codegeneration/csharp/Generator.js
@@ -28,10 +28,10 @@ module.exports = (superclass) => class ExtendedVisitor extends superclass {
    * @returns {string} - visited expression
    */
   emitNew(ctx) {
-    const expr = this.visit(ctx.singleExpression());
-    ctx.type = ctx.singleExpression().type;
-
-    return expr;
+    const expr = this.getExpression(ctx);
+    const str = this.visit(expr);
+    ctx.type = expr.type;
+    return str;
   }
 
   /**
@@ -43,12 +43,10 @@ module.exports = (superclass) => class ExtendedVisitor extends superclass {
    */
   emitSymbol(ctx) {
     ctx.type = this.Types.Symbol;
-    const argsList = ctx.arguments().argumentList();
-    this.checkArguments(this.Symbols.Symbol.args, argsList, 'Symbol');
-    const args = argsList.singleExpression();
-    const expr = args[0].getText();
-
-    return doubleQuoteStringify(expr.toString());
+    this.checkArguments(
+      this.Symbols.Symbol.args, this.getArguments(ctx), 'Symbol'
+    );
+    return doubleQuoteStringify(this.getArgumentAt(ctx, 0).getText());
   }
 
   /**
@@ -88,8 +86,7 @@ module.exports = (superclass) => class ExtendedVisitor extends superclass {
    */
   emitMinKey(ctx) {
     ctx.type = this.Types.MinKey;
-    const argsList = ctx.arguments().argumentList();
-    this.checkArguments(this.Symbols.MinKey.args, argsList, 'MinKey');
+    this.checkArguments(this.Symbols.MinKey.args, this.getArguments(ctx), 'MinKey');
     return 'BsonMinKey.Value';
   }
 
@@ -103,8 +100,9 @@ module.exports = (superclass) => class ExtendedVisitor extends superclass {
    */
   emitMaxKey(ctx) {
     ctx.type = this.Types.MaxKey;
-    const argsList = ctx.arguments().argumentList();
-    this.checkArguments(this.Symbols.MaxKey.args, argsList, 'MaxKey');
+    this.checkArguments(
+      this.Symbols.MaxKey.args, this.getArguments(ctx), 'MaxKey'
+    );
     return 'BsonMaxKey.Value';
   }
 

--- a/codegeneration/javascript/Generator.js
+++ b/codegeneration/javascript/Generator.js
@@ -19,11 +19,11 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
     if (!ctx.wasNew) {
       newstr = 'new ';
     }
-    const args = ctx.arguments();
-    if (!args.argumentList()) {
+    const args = this.getArguments(ctx);
+    if (args.length === 0) {
       return `${newstr}Date()`;
     }
-    const argstr = this.checkArguments([[this.Types._string]], args.argumentList());
+    const argstr = this.checkArguments([[this.Types._string]], args, 'ISODate');
     return `${newstr}Date(${argstr[0]})`;
   }
 
@@ -35,11 +35,11 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
     if (date === undefined) {
       return `${newstr}Date()`;
     }
-    const args = ctx.arguments();
-    if (!args.argumentList()) {
+    const args = this.getArguments(ctx);
+    if (args.length === 0) {
       return ctx.getText();
     }
-    const argstr = this.checkArguments(this.Symbols.Date.args, args.argumentList());
+    const argstr = this.checkArguments(this.Symbols.Date.args, args, 'Date');
     return `${newstr}Date(${argstr.join(', ')})`;
   }
 };

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -951,6 +951,54 @@ class Visitor extends ECMAScriptVisitor {
   processBinary() {
     throw new BsonTranspilersUnimplementedError('Binary type not supported');
   }
+
+  // Getters
+  getExpression(ctx) {
+    return ctx.singleExpression();
+  }
+  getArguments(ctx) {
+    return ctx.arguments().argumentList();
+  }
+  getArgumentAt(ctx, i) {
+    return this.getArguments(ctx).singleExpression()[i];
+  }
+  getList(ctx) {
+    if (!('elementList' in ctx) || !ctx.elementList()) {
+      return [];
+    }
+    return ctx.elementList().singleExpression();
+  }
+  getArray(ctx) {
+    if (!('arrayLiteral' in ctx)) {
+      return false;
+    }
+    return ctx.arrayLiteral();
+  }
+  getObject(ctx) {
+    if (!('objectLiteral' in ctx)) {
+      return false;
+    }
+    return ctx.objectLiteral();
+  }
+  getKeyValueList(ctx) {
+    if ('propertyNameAndValueList' in ctx && ctx.propertyNameAndValueList()) {
+      return ctx.propertyNameAndValueList().propertyAssignment();
+    }
+    return [];
+  }
+  getKey(ctx) {
+    return ctx.propertyName();
+  }
+  getValue(ctx) {
+    return ctx.singleExpression();
+  }
+  isSubObject(ctx) {
+    return 'propertyName' in ctx.parentCtx.parentCtx;
+  }
+  // For a given sub document, get its key.
+  getParentKey(ctx) {
+    return ctx.parentCtx.parentCtx.propertyName();
+  }
 }
 
 module.exports = Visitor;

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -154,9 +154,9 @@ class Visitor extends ECMAScriptVisitor {
     let code = '';
     for (let i = opts.start; i <= opts.end; i += opts.step) {
       if (opts.ignore.indexOf(i) === -1) {
-        code += this.visit(
-          opts.children[i]) + (i === opts.end ? '' : opts.separator
-        );
+        code = `${code}${this.visit(
+          opts.children[i]
+        )}${(i === opts.end) ? '' : opts.separator}`;
       }
     }
     /* Set the node's type to the first child, if it's not already set.
@@ -624,12 +624,12 @@ class Visitor extends ECMAScriptVisitor {
       }
       const result = this.castType(expected[i], args[i]);
       if (result === null) {
+        const typeStr = expected[i].map((e) => {
+          const id = e && e.id ? e.id : e;
+          return e ? id : '[optional]';
+        });
         const message = `Argument type mismatch: '${name}' expects types ${
-          expected[i].map((e) => {
-            const id = e && e.id ? e.id : e;
-            return e ? id : '[optional]';
-          })
-        } but got type ${args[i].type.id} for argument at index ${i}`;
+          typeStr} but got type ${args[i].type.id} for argument at index ${i}`;
 
         throw new BsonTranspilersArgumentError(message);
       }

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -154,13 +154,17 @@ class Visitor extends ECMAScriptVisitor {
     let code = '';
     for (let i = opts.start; i <= opts.end; i += opts.step) {
       if (opts.ignore.indexOf(i) === -1) {
-        code += this.visit(opts.children[i]) + (i === opts.end ? '' : opts.separator);
+        code += this.visit(
+          opts.children[i]) + (i === opts.end ? '' : opts.separator
+        );
       }
     }
     /* Set the node's type to the first child, if it's not already set.
       More often than not, type will be set directly by the visitNode method. */
     if (ctx.type === undefined) {
-      ctx.type = opts.children.length ? opts.children[0].type : this.Types._undefined;
+      ctx.type = opts.children.length ?
+        opts.children[0].type :
+        this.Types._undefined;
     }
     return code.trim();
   }
@@ -229,7 +233,10 @@ class Visitor extends ECMAScriptVisitor {
       const properties = ctx.propertyNameAndValueList().propertyAssignment();
       if (ctx.type.argsTemplate) {
         args = ctx.type.argsTemplate(properties.map((pair) => {
-          return [this.visit(pair.propertyName()), this.visit(pair.singleExpression())];
+          return [
+            this.visit(pair.propertyName()),
+            this.visit(pair.singleExpression())
+          ];
         }), ctx.indentDepth);
       } else {
         args = this.visit(properties);
@@ -315,10 +322,14 @@ class Visitor extends ECMAScriptVisitor {
 
     // Check arguments
     const expectedArgs = lhsType.args;
-    let rhs = this.checkArguments(expectedArgs, ctx.arguments().argumentList(), lhsType.id);
+    let rhs = this.checkArguments(
+      expectedArgs, ctx.arguments().argumentList(), lhsType.id
+    );
 
     // Add new if needed
-    const newStr = lhsType.callable === this.SYMBOL_TYPE.CONSTRUCTOR ? this.new : '';
+    const newStr = lhsType.callable === this.SYMBOL_TYPE.CONSTRUCTOR ?
+      this.new :
+      '';
 
     // Apply the arguments template
     if (lhsType.argsTemplate) {
@@ -360,8 +371,11 @@ class Visitor extends ECMAScriptVisitor {
     const lhs = this.visit(ctx.singleExpression());
     const rhs = this.visit(ctx.identifierName());
 
-    if (!ctx.singleExpression().constructor.name.includes('Identifier') && !ctx.singleExpression().constructor.name.includes('FuncCall')) {
-      throw new BsonTranspilersUnimplementedError('Attribute access for non-symbols not currently supported');
+    if (!ctx.singleExpression().constructor.name.includes('Identifier') &&
+        !ctx.singleExpression().constructor.name.includes('FuncCall')) {
+      throw new BsonTranspilersUnimplementedError(
+        'Attribute access for non-symbols not currently supported'
+      );
     }
 
     let type = ctx.singleExpression().type;
@@ -610,10 +624,12 @@ class Visitor extends ECMAScriptVisitor {
       }
       const result = this.castType(expected[i], args[i]);
       if (result === null) {
-        const message = `Argument type mismatch: '${name}' expects types ${expected[i].map((e) => {
-          const id = e && e.id ? e.id : e;
-          return e ? id : '[optional]';
-        })} but got type ${args[i].type.id} for argument at index ${i}`;
+        const message = `Argument type mismatch: '${name}' expects types ${
+          expected[i].map((e) => {
+            const id = e && e.id ? e.id : e;
+            return e ? id : '[optional]';
+          })
+        } but got type ${args[i].type.id} for argument at index ${i}`;
 
         throw new BsonTranspilersArgumentError(message);
       }
@@ -639,7 +655,9 @@ class Visitor extends ECMAScriptVisitor {
 
     // Get the original type of the argument
     const expectedArgs = lhsType.args;
-    let args = this.checkArguments(expectedArgs, ctx.arguments().argumentList(), lhsType.id);
+    let args = this.checkArguments(
+      expectedArgs, ctx.arguments().argumentList(), lhsType.id
+    );
     let argType;
 
     if (!ctx.arguments().argumentList()) {
@@ -648,7 +666,9 @@ class Visitor extends ECMAScriptVisitor {
     } else {
       const argNode = ctx.arguments().argumentList().singleExpression()[0];
       const typed = this.getTyped(argNode);
-      argType = typed.originalType !== undefined ? typed.originalType : typed.type;
+      argType = typed.originalType !== undefined ?
+        typed.originalType :
+        typed.type;
     }
 
     if (`emit${lhsType.id}` in this) {
@@ -657,7 +677,9 @@ class Visitor extends ECMAScriptVisitor {
 
     // Apply the arguments template
     const lhs = lhsType.template ? lhsType.template() : lhsStr;
-    const rhs = lhsType.argsTemplate ? lhsType.argsTemplate(lhs, args[0], argType.id) : `(${args.join(', ')})`;
+    const rhs = lhsType.argsTemplate ?
+      lhsType.argsTemplate(lhs, args[0], argType.id) :
+      `(${args.join(', ')})`;
     return `${lhs}${rhs}`;
   }
 
@@ -694,7 +716,9 @@ class Visitor extends ECMAScriptVisitor {
     }
 
     let targetflags = flags.replace(/[imuyg]/g, m => this.regexFlags[m]);
-    targetflags = targetflags === '' ? '' : `${targetflags.split('').sort().join('')}`;
+    targetflags = targetflags === '' ?
+      '' :
+      `${targetflags.split('').sort().join('')}`;
 
     if ('emitRegExp' in this) {
       return this.emitRegExp(ctx, pattern, targetflags);
@@ -717,7 +741,9 @@ class Visitor extends ECMAScriptVisitor {
     const symbolType = this.Symbols.BSONRegExp;
 
     const argList = ctx.arguments().argumentList();
-    const args = this.checkArguments([[this.Types._string], [this.Types._string, null]], argList, 'BSONRegExp');
+    const args = this.checkArguments(
+      [[this.Types._string], [this.Types._string, null]], argList, 'BSONRegExp'
+    );
 
     let flags = null;
     const pattern = args[0];
@@ -725,7 +751,9 @@ class Visitor extends ECMAScriptVisitor {
       flags = args[1];
       for (let i = 1; i < flags.length - 1; i++) {
         if (!(flags[i] in this.bsonRegexFlags)) {
-          throw new BsonTranspilersRuntimeError(`Invalid flag '${flags[i]}' passed to BSONRegExp`);
+          throw new BsonTranspilersRuntimeError(
+            `Invalid flag '${flags[i]}' passed to BSONRegExp`
+          );
         }
       }
       flags = flags.replace(/[imxlsu]/g, m => this.bsonRegexFlags[m]);
@@ -735,7 +763,9 @@ class Visitor extends ECMAScriptVisitor {
       return this.emitBSONRegExp(ctx, pattern, flags);
     }
     const lhs = symbolType.template ? symbolType.template() : 'BSONRegExp';
-    const rhs = symbolType.argsTemplate ? symbolType.argsTemplate(lhs, pattern, flags) : `(${pattern}${flags ? ', ' + flags : ''})`;
+    const rhs = symbolType.argsTemplate ?
+      symbolType.argsTemplate(lhs, pattern, flags) :
+      `(${pattern}${flags ? ', ' + flags : ''})`;
     return `${this.new}${lhs}${rhs}`;
   }
 
@@ -781,7 +811,9 @@ class Visitor extends ECMAScriptVisitor {
       return this.emitCode(ctx, code, scope);
     }
     const lhs = symbolType.template ? symbolType.template() : 'Code';
-    const rhs = symbolType.argsTemplate ? symbolType.argsTemplate(lhs, code, scope) : `(${code}${scopestr})`;
+    const rhs = symbolType.argsTemplate ?
+      symbolType.argsTemplate(lhs, code, scope) :
+      `(${code}${scopestr})`;
     return `${this.new}${lhs}${rhs}`;
   }
 
@@ -809,7 +841,9 @@ class Visitor extends ECMAScriptVisitor {
     if ('emitObjectId' in this) {
       return this.emitObjectId(ctx, hexstr);
     }
-    const rhs = symbolType.argsTemplate ? symbolType.argsTemplate(lhs, hexstr) : `(${hexstr})`;
+    const rhs = symbolType.argsTemplate ?
+      symbolType.argsTemplate(lhs, hexstr) :
+      `(${hexstr})`;
     return `${this.new}${lhs}${rhs}`;
   }
 
@@ -834,7 +868,9 @@ class Visitor extends ECMAScriptVisitor {
       return this.emitLong(ctx, longstr);
     }
     const lhs = symbolType.template ? symbolType.template() : 'Long';
-    const rhs = symbolType.argsTemplate ? symbolType.argsTemplate(lhs, longstr) : `(${longstr})`;
+    const rhs = symbolType.argsTemplate ?
+      symbolType.argsTemplate(lhs, longstr) :
+      `(${longstr})`;
     return `${this.new}${lhs}${rhs}`;
   }
 
@@ -876,7 +912,9 @@ class Visitor extends ECMAScriptVisitor {
       return this.emitDecimal128(ctx, decstr);
     }
     const lhs = symbolType.template ? symbolType.template() : 'Decimal128';
-    const rhs = symbolType.argsTemplate ? symbolType.argsTemplate(lhs, decstr) : `(${decstr})`;
+    const rhs = symbolType.argsTemplate ?
+      symbolType.argsTemplate(lhs, decstr) :
+      `(${decstr})`;
     return `${this.new}${lhs}${rhs}`;
   }
 

--- a/codegeneration/python/Generator.js
+++ b/codegeneration/python/Generator.js
@@ -35,11 +35,10 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
    * @return {String}
    */
   emitNew(ctx) {
-    const expr = this.visit(ctx.singleExpression());
-
-    ctx.type = ctx.singleExpression().type;
-
-    return expr;
+    const expr = this.getExpression(ctx);
+    const str = this.visit(expr);
+    ctx.type = expr.type;
+    return str;
   }
 
   /**
@@ -90,10 +89,12 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
     ctx.type = 'createFromTime' in this.Symbols.ObjectId.attr ?
       this.Symbols.ObjectId.attr.createFromTime :
       this.Symbols.ObjectId.attr.fromDate;
-    const argList = ctx.arguments().argumentList();
-    const args = this.checkArguments(ctx.type.args, argList);
+    const argList = this.getArguments(ctx);
+    const args = this.checkArguments(
+      ctx.type.args, argList, 'ObjectId.createFromTime'
+    );
     const template = ctx.type.template ? ctx.type.template() : '';
-    if (argList.singleExpression()[0].type.id === 'Date') {
+    if (this.getArgumentAt(ctx, 0).type.id === 'Date') {
       return `${template}${ctx.type.argsTemplate('', args[0])}`;
     }
     return `${template}${ctx.type.argsTemplate(


### PR DESCRIPTION
This is the last major thing that needed to be done before we can start on adding new visitors/input languages.

This PR adds accessor methods to the visitor so that the generator does not need to call or know anything specific about the tree being traversed. 

For example: previously to get the arguments of a function call, the generator would call `ctx.arguments().argumentsList().singleExpression()`. Now it just calls `this.getArguments(ctx)`, which is defined in the visitor (which returns `ctx.arguments().argumentsList().singleExpression()`).

This is required because when we have multiple trees, the tree access will have different names (or even different shapes) so we want to abstract the data access to the visitor so the generators can be truly input-language agnostic.

As I was going through the code I also found a few places where the lines were very long (esp long ternary statements!) and added newlines between them in the files that I was already working in.