### PR TITLE
COMPASS-3823: Add git info for license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "check": "mongodb-js-precommit './codegeneration/**/*{.js,.jsx}' './test/**/*.js' index.js",
     "ci": "npm run check && npm run test"
   },
+  "homepage": "http://github.com/mongodb-js/bson-transpilers",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mongodb-js/bson-transpilers.git"
+  },
   "precommit": [
     "check"
   ],


### PR DESCRIPTION
This PR adds the git URL to package.json so compass can exclude it as a third party dependency when generating licensing information.