### PR TITLE
feat: compile functions to js

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,25 @@
+name: Run Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  check-and-test:
+    name: Check and Test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.4.0
+
+      - name: Install NPM Packages
+        run: npm ci
+
+      - name: Check and Test
+        run: |
+          npm run check
+          npm run compile
+          npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-sudo: false
-node_js:
-  - 9.8.0
-install: npm install --ignore-scripts
-script: npm run ci
-cache:
-  directories:
-  - node_modules

--- a/codegeneration/CodeGenerationVisitor.js
+++ b/codegeneration/CodeGenerationVisitor.js
@@ -788,6 +788,12 @@ module.exports = (ANTLRVisitor) => class CodeGenerationVisitor extends ANTLRVisi
     );
   }
 
+  generateFuncDefExpression() {
+    throw new BsonTranspilersUnimplementedError(
+      'Support for exporting functions to languages other than javascript is not yet available.'
+    );
+  }
+
   /**
    * Overrides the ANTLR visitChildren method so that options can be set.
    *

--- a/codegeneration/javascript/Generator.js
+++ b/codegeneration/javascript/Generator.js
@@ -5,4 +5,8 @@ module.exports = (Visitor) => class Generator extends Visitor {
   constructor() {
     super();
   }
+
+  generateFuncDefExpression(ctx) {
+    return ctx.getText();
+  }
 };

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -296,11 +296,6 @@ module.exports = (CodeGenerationVisitor) => class Visitor extends CodeGeneration
    * Process Methods
    *
    */
-  generateFuncDefExpression() {
-    throw new BsonTranspilersUnimplementedError(
-      'Support for exporting functions to languages other than javascript is not yet available.'
-    );
-  }
 
   /* Numerical process methods */
   processNumber(ctx) {

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -28,7 +28,6 @@ module.exports = (CodeGenerationVisitor) => class Visitor extends CodeGeneration
     this.visitTypeofExpression =
     this.visitInExpression =
     this.visitInstanceofExpression =
-    this.visitFuncDefExpression =
     this.visitAssignmentExpression =
     this.visitAssignmentOperatorExpression =
     this.visitMemberIndexExpression =
@@ -288,11 +287,20 @@ module.exports = (CodeGenerationVisitor) => class Visitor extends CodeGeneration
     return this.visitChildren(ctx);
   }
 
+  visitFuncDefExpression(ctx) {
+    return this.generateFuncDefExpression(ctx);
+  }
+
   /*
    *
    * Process Methods
    *
    */
+  generateFuncDefExpression() {
+    throw new BsonTranspilersUnimplementedError(
+      'Support for exporting functions to languages other than javascript is not yet available.'
+    );
+  }
 
   /* Numerical process methods */
   processNumber(ctx) {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
     "antlr4-js": "java -Xmx500M -cp './antlr-4.7.2-complete.jar:$CLASSPATH' org.antlr.v4.Tool  -Dlanguage=JavaScript -lib grammars -o lib/antlr -visitor -Xexact-output-dir grammars/ECMAScript.g4",
     "antlr4-py": "java -Xmx500M -cp './antlr-4.7.2-complete.jar:$CLASSPATH' org.antlr.v4.Tool  -Dlanguage=JavaScript -lib grammars -o lib/antlr -visitor -Xexact-output-dir grammars/Python3.g4",
     "symbol-table": "node compile-symbol-table.js",
-    "test": "npm run symbol-table && mocha",
+    "test": "mocha",
     "prepublishOnly": "npm run compile",
-    "check": "mongodb-js-precommit './codegeneration/**/*{.js,.jsx}' './test/**/*.js' index.js",
-    "ci": "npm run check && npm run test"
+    "check": "mongodb-js-precommit './codegeneration/**/*{.js,.jsx}' './test/**/*.js' index.js"
   },
   "homepage": "http://github.com/mongodb-js/bson-transpilers",
   "repository": {

--- a/test/functions.test.js
+++ b/test/functions.test.js
@@ -1,0 +1,29 @@
+const bsonTranspilers = require('..');
+const assert = require('assert');
+
+const {
+  BsonTranspilersUnimplementedError
+} = require('../helper/error');
+
+describe('function expressions (shell)', () => {
+  it('compiles functions to javascript', () => {
+    assert.strictEqual(
+      bsonTranspilers.shell.javascript.compile('function(){}'),
+      'function(){}'
+    );
+  });
+
+  ['object', 'csharp', 'java', 'python'].forEach((language) => {
+    it(`throws an unsupported error compiling functions to ${language}`, () => {
+      assert.throws(
+        () => {
+          bsonTranspilers.shell[language].compile('function(){}');
+        },
+        new BsonTranspilersUnimplementedError(
+          'Support for exporting functions to languages other than javascript is not yet available.'
+        )
+      );
+    });
+  });
+});
+


### PR DESCRIPTION
- Allow functions to be compiled to javascript.
- Throws `Support for exporting functions to languages other than javascript is not yet available.` for other languages.

Other changes:

- Move CI from travis to github workflows

NOTE: Arrow functions are not supported by the grammar. Updating the grammar with a [newer version](https://raw.githubusercontent.com/antlr/grammars-v4/master/javascript/ecmascript/JavaScript/ECMAScript.g4) breaks other features.

